### PR TITLE
Fix episode number parsing for epguides.com

### DIFF
--- a/extras/episoder_helper_epguides.awk
+++ b/extras/episoder_helper_epguides.awk
@@ -98,11 +98,7 @@ function set_show(showName) {
 /^[0-9]+/ {
 	# A data file format used for shows like Eureka
 	totalep = $1
-	epnum = substr($0, index($0, "-")+1, 2)
-
-	if (epnum < 10) {
-		epnum = 0 substr(epnum, 2, 1)
-	}
+	epnum = int(substr($0, index($0, "-")+1, 2))
 
 	prodnum = substr($0, 16, 9)
 	gsub(/^ */, "", prodnum)
@@ -133,11 +129,7 @@ function set_show(showName) {
 /^ *[0-9]+\./ {
 	totalep = substr ($1, 0, index($1, "."))
 	gsub (/\.$/, "", totalep)
-	epnum = substr($0, index($0, "-")+1, 2)
-
-	if (epnum < 10) {
-		epnum = 0 substr(epnum, 2, 1)
-	}
+	epnum = int(substr($0, index($0, "-")+1, 2))
 
 	prodnum = substr($0, 16, 9)
 	gsub(/^ */, "", prodnum)


### PR DESCRIPTION
epguides.com recently changed it formatting, episode numbers under 10 are no longer prefixed with a zero. The awk script used a string-comparison, for which `"1" < "10"` is true, resulting in episode 1 being numbered as episode 0 instead.

This patch converts the episode number to an actual number. I don't see a reason to output a two-digit number always.